### PR TITLE
Blogsコントローラを追加

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,0 +1,10 @@
+class BlogsController < ApplicationController
+  def show
+  end
+
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -14,7 +14,7 @@ class BlogsController < ApplicationController
     @blog = Blog.new(blog_params)
     @blog.user_id = current_user.id
     if @blog.save
-      redirect_to(location_of(@blog))
+      redirect_to_blog(@blog)
     else
       render :new
     end
@@ -27,7 +27,7 @@ class BlogsController < ApplicationController
   def update
     @blog = Blog.find(params[:id])
     if @blog.update_attributes(blog_params)
-      redirect_to(location_of(@blog))
+      redirect_to_blog(@blog)
     else
       render :edit
     end
@@ -44,7 +44,7 @@ class BlogsController < ApplicationController
     params.require(:blog).permit(:title, :description, :name)
   end
 
-  def location_of(blog)
-    "/blog/#{blog.name}"
+  def redirect_to_blog(blog)
+    redirect_to("/blog/#{blog.name}")
   end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,10 +1,50 @@
+# frozen_string_literal: true
+
 class BlogsController < ApplicationController
+  before_action :require_login, only: [:new, :create, :edit, :update, :destroy]
   def show
+    @blog = Blog.find_by(name: params[:name])
   end
 
   def new
+    @blog = Blog.new
+  end
+
+  def create
+    @blog = Blog.new(blog_params)
+    @blog.user_id = current_user.id
+    if @blog.save
+      redirect_to(location_of(@blog))
+    else
+      render :new
+    end
   end
 
   def edit
+    @blog = Blog.find(params[:id])
+  end
+
+  def update
+    @blog = Blog.find(params[:id])
+    if @blog.update_attributes(blog_params)
+      redirect_to(location_of(@blog))
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    Blog.find(params[:id]).destroy
+    redirect_to(current_user)
+  end
+
+  private
+
+  def blog_params
+    params.require(:blog).permit(:title, :description, :name)
+  end
+
+  def location_of(blog)
+    "/blog/#{blog.name}"
   end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -4,6 +4,7 @@ class BlogsController < ApplicationController
   before_action :require_login, only: [:new, :create, :edit, :update, :destroy]
   def show
     @blog = Blog.find_by(name: params[:name])
+    @articles = @blog.articles
   end
 
   def new

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -22,24 +22,30 @@ class BlogsController < ApplicationController
 
   def edit
     @blog = Blog.find(params[:id])
-    check_authority(@blog)
+    redirect_to_blog unless authorized?(@blog)
   end
 
   def update
     @blog = Blog.find(params[:id])
-    check_authority(@blog)
-    if @blog.update_attributes(blog_params)
-      redirect_to_blog(@blog)
+    if authorized?(@blog)
+      if @blog.update_attributes(blog_params)
+        redirect_to_blog(@blog)
+      else
+        render :edit
+      end
     else
-      render :edit
+      redirect_to_blog(@blog)
     end
   end
 
   def destroy
     blog = Blog.find(params[:id])
-    check_authority(blog)
-    blog.destroy
-    redirect_to(current_user)
+    if authorized?(blog)
+      blog.destroy
+      redirect_to(current_user)
+    else
+      redirect_to_blog(blog)
+    end
   end
 
   private
@@ -52,7 +58,7 @@ class BlogsController < ApplicationController
     redirect_to("/blog/#{blog.name}")
   end
 
-  def check_authority(blog)
-    redirect_to_blog(blog) unless blog.user_id == current_user.id
+  def authorized?(blog)
+    blog.user_id == current_user.id
   end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -22,10 +22,12 @@ class BlogsController < ApplicationController
 
   def edit
     @blog = Blog.find(params[:id])
+    check_authority(@blog)
   end
 
   def update
     @blog = Blog.find(params[:id])
+    check_authority(@blog)
     if @blog.update_attributes(blog_params)
       redirect_to_blog(@blog)
     else
@@ -34,7 +36,9 @@ class BlogsController < ApplicationController
   end
 
   def destroy
-    Blog.find(params[:id]).destroy
+    blog = Blog.find(params[:id])
+    check_authority(blog)
+    blog.destroy
     redirect_to(current_user)
   end
 
@@ -46,5 +50,9 @@ class BlogsController < ApplicationController
 
   def redirect_to_blog(blog)
     redirect_to("/blog/#{blog.name}")
+  end
+
+  def check_authority(blog)
+    redirect_to_blog(blog) unless blog.user_id == current_user.id
   end
 end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -1,0 +1,2 @@
+module BlogsHelper
+end

--- a/app/views/blogs/edit.html.erb
+++ b/app/views/blogs/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Blogs#edit</h1>
+<p>Find me in app/views/blogs/edit.html.erb</p>

--- a/app/views/blogs/edit.html.erb
+++ b/app/views/blogs/edit.html.erb
@@ -1,2 +1,18 @@
 <h1>Blogs#edit</h1>
-<p>Find me in app/views/blogs/edit.html.erb</p>
+<%= form_for @blog do |f| %>
+  <%= f.label :title, 'ブログタイトル' %>
+  <%= f.text_field :title %>
+  <%= f.label :description, 'ブログ説明(255文字以内)' %>
+  <%= f.text_field :description %>
+  <%= f.label :name, 'ブログID(半角英数とアンダーバーのみ)' %>
+  <%= f.text_field :name %>
+  <% if @blog.errors.any? %>
+    <h2>エラー</h2>
+    <ul>
+      <% @blog.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <%= f.submit "更新" %>
+<% end %>

--- a/app/views/blogs/new.html.erb
+++ b/app/views/blogs/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Blogs#new</h1>
+<p>Find me in app/views/blogs/new.html.erb</p>

--- a/app/views/blogs/new.html.erb
+++ b/app/views/blogs/new.html.erb
@@ -1,2 +1,18 @@
 <h1>Blogs#new</h1>
-<p>Find me in app/views/blogs/new.html.erb</p>
+<%= form_for @blog, url: { action: :create } do |f| %>
+  <%= f.label :title, 'ブログタイトル' %>
+  <%= f.text_field :title %>
+  <%= f.label :description, 'ブログ説明(255文字以内)' %>
+  <%= f.text_field :description %>
+  <%= f.label :name, 'ブログID(半角英数とアンダーバーのみ)' %>
+  <%= f.text_field :name %>
+  <% if @blog.errors.any? %>
+    <h2>エラー</h2>
+    <ul>
+      <% @blog.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <%= f.submit "作成" %>
+<% end %>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Blogs#show</h1>
+<p>Find me in app/views/blogs/show.html.erb</p>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,5 +1,8 @@
 <h1><%= @blog.title =%></h1>
 <p><%= @blog.description =%></p>
+<% @articles.each do |article| %>
+  <%= article.title %>
+<% end %>
 <% if @blog.user_id == current_user.id %>
   <ul>
     <li><%= link_to('編集', edit_blog_path(@blog)) =%></li>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,2 +1,8 @@
 <h1><%= @blog.title =%></h1>
 <p><%= @blog.description =%></p>
+<% if @blog.user_id == current_user.id %>
+  <ul>
+    <li><%= link_to('編集', edit_blog_path(@blog)) =%></li>
+    <li><%= link_to('削除', blog_path(@blog), method: :delete) =%></li>
+  </ul>
+<% end %>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,2 +1,2 @@
-<h1>Blogs#show</h1>
-<p>Find me in app/views/blogs/show.html.erb</p>
+<h1><%= @blog.title =%></h1>
+<p><%= @blog.description =%></p>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,11 +1,11 @@
-<h1><%= @blog.title =%></h1>
-<p><%= @blog.description =%></p>
+<h1><%= @blog.title %></h1>
+<p><%= @blog.description %></p>
 <% @articles.each do |article| %>
   <%= article.title %>
 <% end %>
 <% if @blog.user_id == current_user.id %>
   <ul>
-    <li><%= link_to('編集', edit_blog_path(@blog)) =%></li>
-    <li><%= link_to('削除', blog_path(@blog), method: :delete) =%></li>
+    <li><%= link_to('編集', edit_blog_path(@blog)) %></li>
+    <li><%= link_to('削除', blog_path(@blog), method: :delete) %></li>
   </ul>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
-  get 'blogs/show'
-
-  get 'blogs/new'
-
-  get 'blogs/edit'
-
   resources :users, only: [:new, :create, :show]
+  resources :blogs, except: [:index, :show]
+  get '/blog/:name', to: 'blogs#show'
   get '/login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  get 'blogs/show'
+
+  get 'blogs/new'
+
+  get 'blogs/edit'
+
   resources :users, only: [:new, :create, :show]
   get '/login', to: 'sessions#new'
   post 'login', to: 'sessions#create'

--- a/test/controllers/blogs_controller_test.rb
+++ b/test/controllers/blogs_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class BlogsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get blogs_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get blogs_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get blogs_edit_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
## 作業内容:hatched_chick:

- index以外のアクション(show, new, create, edit, update, destroy)を作成
- ルーティングを追加
showアクションのみurlにnameカラムを使う関係上、
例えばnameにnew等の予約語?を保存するとパスが被るので
`/blogs/~~~`ではなく`/blog/~~~`に設定
- ブログ作成ユーザー以外がedit, update, destroyできないように設定
- showに記事タイトル一覧を表示

追加したメソッド説明
- blog_params
ストロングパラメータ用
- redirect_to_blog(blog)
redirect_to(blog)だと`/blogs/:id`に飛んでしまうので、
'/blog/:name'に飛ばすためのもの
- authorized?(blog)
編集・削除する際に、カレントユーザーが作成ユーザーかどうか判定するもの。

## 動作確認項目:eyes:
なし

## 進歩状況:clipboard:
> - [x] PR作成
> - [ ] レビュー依頼
