### PR TITLE
バリデーションの正規表現のアンカーを修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,6 +6,6 @@ class Article < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :name, presence: true,
                    length: { maximum: 255 },
-                   format: { with: /^\w+$/ },
+                   format: { with: /\A\w+\z/ },
                    uniqueness: { scope: :blog_id }
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -8,6 +8,6 @@ class Blog < ApplicationRecord
   validates :description, presence: true, length: { maximum: 255 }
   validates :name, presence: true,
                    length: { maximum: 255 },
-                   format: { with: /^\w+$/ },
+                   format: { with: /\A\w+\z/ },
                    uniqueness: true
 end


### PR DESCRIPTION
## 作業内容:hatched_chick:

```
validates :name,  format: { with: /^\w+$/ },
```
だと

> The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \A and \z, or forgot to add the :multiline => true option?

のエラーが出たので
```
validates :name,  format: { with: /\A\w+\z/ },
```
に修正

[参考: Rails4では正規表現が厳しくなった。](http://jumperson.hatenablog.com/entry/2013/06/27/062237)
## 動作確認項目:eyes:
なし

## 進歩状況:clipboard:
> - [x] PR作成
> - [ ] レビュー依頼
