### PR TITLE
Blogsコントローラを作成#2

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,0 +1,10 @@
+class BlogsController < ApplicationController
+  def show
+  end
+
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -2,6 +2,7 @@
 
 class BlogsController < ApplicationController
   require 'securerandom'
+  include BlogsHelper
   before_action :set_blog, only: [:show, :edit, :update, :destroy]
   before_action :require_login, only: [:new, :edit, :update, :destroy]
   def show
@@ -53,10 +54,6 @@ class BlogsController < ApplicationController
 
   def redirect_to_blog(blog)
     redirect_to("/blogs/#{blog.name}")
-  end
-
-  def authorized?(blog)
-    blog.user_id == current_user.id
   end
 
   def set_blog

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -60,6 +60,6 @@ class BlogsController < ApplicationController
   end
 
   def set_blog
-    @blog = Blog.friendly.find(params[:id])
+    @blog = Blog.friendly.find(params[:name])
   end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
 class BlogsController < ApplicationController
+  require 'securerandom'
   before_action :set_blog, only: [:show, :edit, :update, :destroy]
-  before_action :require_login, only: [:new, :create, :edit, :update, :destroy]
+  before_action :require_login, only: [:new, :edit, :update, :destroy]
   def show
   end
 
   def new
-    @blog = Blog.new
-  end
-
-  def create
-    @blog = Blog.new(blog_params)
-    @blog.user_id = current_user.id
-    if @blog.save
-      redirect_to_blog(@blog)
+    if current_user.blogs.empty?
+      @blog = Blog.new
+      @blog.name = SecureRandom.hex(8)
+      @blog.title = current_user.name + 'のブログ'
+      @blog.description = 'ブログの説明文'
+      @blog.user_id = current_user.id
+      redirect_to(edit_blog_path(@blog.name)) if @blog.save
     else
-      render :new
+      redirect_to(blog_path(current_user.blogs.first.name))
     end
   end
 

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -22,18 +22,18 @@ class BlogsController < ApplicationController
   end
 
   def edit
-    redirect_to_blog unless authorized?(@blog)
+    redirect_to(blog_path(@blog.name)) unless authorized?(@blog)
   end
 
   def update
     if authorized?(@blog)
       if @blog.update_attributes(blog_params)
-        redirect_to_blog(@blog)
+        redirect_to(blog_path(@blog.name))
       else
         render :edit
       end
     else
-      redirect_to_blog(@blog)
+      redirect_to(blog_path(@blog.name))
     end
   end
 
@@ -42,7 +42,7 @@ class BlogsController < ApplicationController
       @blog.destroy
       redirect_to(current_user)
     else
-      redirect_to_blog(@blog)
+      redirect_to(blog_path(@blog.name))
     end
   end
 
@@ -50,10 +50,6 @@ class BlogsController < ApplicationController
 
   def blog_params
     params.require(:blog).permit(:title, :description, :name)
-  end
-
-  def redirect_to_blog(blog)
-    redirect_to("/blogs/#{blog.name}")
   end
 
   def set_blog

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,10 +1,65 @@
+# frozen_string_literal: true
+
 class BlogsController < ApplicationController
+  before_action :set_blog, only: [:show, :edit, :update, :destroy]
+  before_action :require_login, only: [:new, :create, :edit, :update, :destroy]
   def show
   end
 
   def new
+    @blog = Blog.new
+  end
+
+  def create
+    @blog = Blog.new(blog_params)
+    @blog.user_id = current_user.id
+    if @blog.save
+      redirect_to_blog(@blog)
+    else
+      render :new
+    end
   end
 
   def edit
+    redirect_to_blog unless authorized?(@blog)
+  end
+
+  def update
+    if authorized?(@blog)
+      if @blog.update_attributes(blog_params)
+        redirect_to_blog(@blog)
+      else
+        render :edit
+      end
+    else
+      redirect_to_blog(@blog)
+    end
+  end
+
+  def destroy
+    if authorized?(@blog)
+      @blog.destroy
+      redirect_to(current_user)
+    else
+      redirect_to_blog(@blog)
+    end
+  end
+
+  private
+
+  def blog_params
+    params.require(:blog).permit(:title, :description, :name)
+  end
+
+  def redirect_to_blog(blog)
+    redirect_to("/blogs/#{blog.name}")
+  end
+
+  def authorized?(blog)
+    blog.user_id == current_user.id
+  end
+
+  def set_blog
+    @blog = Blog.friendly.find(params[:id])
   end
 end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -1,0 +1,2 @@
+module BlogsHelper
+end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -1,2 +1,7 @@
+# frozen_string_literal: true
+
 module BlogsHelper
+  def authorized?(blog)
+    blog.user_id == current_user.id
+  end
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -10,4 +10,6 @@ class Blog < ApplicationRecord
                    length: { maximum: 255 },
                    format: { with: /\A\w+\z/ },
                    uniqueness: true
+  extend FriendlyId
+  friendly_id :name
 end

--- a/app/views/blogs/edit.html.erb
+++ b/app/views/blogs/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Blogs#edit</h1>
+<p>Find me in app/views/blogs/edit.html.erb</p>

--- a/app/views/blogs/edit.html.erb
+++ b/app/views/blogs/edit.html.erb
@@ -1,2 +1,18 @@
-<h1>Blogs#edit</h1>
-<p>Find me in app/views/blogs/edit.html.erb</p>
+<h1>ブログ情報編集</h1>
+<%= form_for @blog, url: { action: :update } do |f| %>
+  <%= f.label :title, 'ブログタイトル' %>
+  <%= f.text_field :title %>
+  <%= f.label :description, '概要' %>
+  <%= f.text_field :description %>
+  <%= f.label :name, 'ブログのパス' %>
+  <%= f.text_field :name %>
+  <% if @blog.errors.any? %>
+    <h2>エラー</h2>
+    <ul>
+      <% @blog.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <%= f.submit "更新" %>
+<% end %>

--- a/app/views/blogs/new.html.erb
+++ b/app/views/blogs/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Blogs#new</h1>
+<p>Find me in app/views/blogs/new.html.erb</p>

--- a/app/views/blogs/new.html.erb
+++ b/app/views/blogs/new.html.erb
@@ -1,2 +1,0 @@
-<h1>Blogs#new</h1>
-<p>Find me in app/views/blogs/new.html.erb</p>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Blogs#show</h1>
+<p>Find me in app/views/blogs/show.html.erb</p>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,2 +1,22 @@
-<h1>Blogs#show</h1>
-<p>Find me in app/views/blogs/show.html.erb</p>
+<div id="header">
+  <h1><%= @blog.name %></h1>
+  <p><%= @blog.id %></p>
+</div>
+<div id="articles">
+  <% @blog.articles.each do |article| %>
+    <div class="article">
+      <h2><%= article.title %></h2>
+      <p><%= article.content %></p>
+      <p><%= article.category.name %></p>
+      <p><%= article.created_at %></p>
+    </div>
+  <% end %>
+</div>
+<div id="footer">
+  <% if true %>
+    <ul>
+      <li><%= link_to("編集", edit_blog_path(@blog.name)) %></li>
+      <li><%= link_to("ブログ削除", blog_path(@blog.name), method: :delete) %></li>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 </div>
 <div id="footer">
-  <% if true %>
+  <% if authorized?(@blog) %>
     <ul>
       <li><%= link_to("編集", edit_blog_path(@blog.name)) %></li>
       <li><%= link_to("ブログ削除", blog_path(@blog.name), method: :delete) %></li>

--- a/app/views/blogs/show.html.erb
+++ b/app/views/blogs/show.html.erb
@@ -1,6 +1,6 @@
 <div id="header">
-  <h1><%= @blog.name %></h1>
-  <p><%= @blog.id %></p>
+  <h1><%= @blog.title %></h1>
+  <p><%= @blog.description %></p>
 </div>
 <div id="articles">
   <% @blog.articles.each do |article| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
   resources :users, only: [:new, :create, :show]
-  resources :blogs, except: [:index]
+  resources :blogs, except: [:index], param: :name
   get '/login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
-  get 'blogs/show'
-
-  get 'blogs/new'
-
-  get 'blogs/edit'
-
   resources :users, only: [:new, :create, :show]
+  resources :blogs, except: [:index]
   get '/login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  get 'blogs/show'
+
+  get 'blogs/new'
+
+  get 'blogs/edit'
+
   resources :users, only: [:new, :create, :show]
   get '/login', to: 'sessions#new'
   post 'login', to: 'sessions#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
   resources :users, only: [:new, :create, :show]
-  resources :blogs, except: [:index], param: :name
+  resources :blogs, except: [:index, :create], param: :name
   get '/login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'

--- a/test/controllers/blogs_controller_test.rb
+++ b/test/controllers/blogs_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class BlogsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get blogs_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get blogs_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get blogs_edit_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
## 作業内容:hatched_chick:

前回のPRからの変更点を ~~打ち消し線~~ や **太字** で示しています。

- index以外のアクション(show, new, ~~create~~ , edit, update, destroy)を作成
**`new`で空のブログを作成するように変更したため、`create`を削除**

- ルーティングを追加
~~showアクションのみurlにnameカラムを使う関係上、
例えばnameにnew等の予約語?を保存するとパスが被るので
`/blogs/~~~`ではなく`/blog/~~~`に設定~~
**params[:name]を`show` `edit` `update` `destroy` のパスに使用**

- ブログ作成ユーザー以外がedit, update, destroyできないように設定

- showに記事 ~~タイトル~~一覧 を表示
**記事一覧を表示**


### 追加したメソッド説明
- blog_params
ストロングパラメータ用

- ~~redirect_to_blog(blog)
redirect_to(blog)だと`/blogs/:id`に飛んでしまうので、
'/blog/:name'に飛ばすためのもの~~
**`redirect_to(blog_path(@blog.name))`で事足りるようになったので削除**

- authorized?(blog)
編集・削除する際に、カレントユーザーが作成ユーザーかどうか判定するもの。
**ビューでもつかうため、ヘルパーに移動**

- **set_blog
`param[:name]`からブログを取得して`@blog`に格納するもの。
アクション間で共通で使うのでbefore_actionに設定**

## 動作確認項目:eyes:
なし

## 進歩状況:clipboard:
> - [x] PR作成
> - [ ] レビュー依頼
