### PR TITLE
非ログイン時にauthorized?が呼ばれるとエラーがでるのを修正

### DIFF
--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -2,10 +2,6 @@
 
 module BlogsHelper
   def authorized?(blog)
-    if current_user.nil?
-      redirect_to(login_path)
-    else
-      blog.user_id == current_user.id
-    end
+    blog.user_id == current_user&.id
   end
 end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -2,6 +2,10 @@
 
 module BlogsHelper
   def authorized?(blog)
-    blog.user_id == current_user.id
+    if current_user.nil?
+      redirect_to(login_path)
+    else
+      blog.user_id == current_user.id
+    end
   end
 end


### PR DESCRIPTION
## 作業内容:hatched_chick:

Blogsヘルパーの`authorized?`メソッドについて、
非ログイン時(current_userが存在しない場合)に呼ばれると`current_user.id`の部分でエラーが出るのを
current_userが存在するか検証することで解決

修正前
```
  def authorized?(blog)
      blog.user_id == current_user.id
  end
```
修正後
```
  def authorized?(blog)
    blog.user_id == current_user&.id
  end
```

## 動作確認項目:eyes:
なし

## 進歩状況:clipboard:
> - [x] PR作成
> - [ ] レビュー依頼
